### PR TITLE
Store the disappearing messages timer in the user/group datastore.

### DIFF
--- a/src/main/java/de/thoffbauer/signal4j/store/Group.java
+++ b/src/main/java/de/thoffbauer/signal4j/store/Group.java
@@ -11,6 +11,7 @@ public class Group {
 	private ArrayList<String> members;
 	private String avatarId;
 	private boolean active;
+	private int messageExpirationTime;
 	
 	public Group() {
 		
@@ -67,4 +68,11 @@ public class Group {
 		this.avatarId = avatarId;
 	}
 
+	public int getMessageExpirationTime() {
+		return messageExpirationTime;
+	}
+
+	public void setMessageExpirationTime(int messageExpirationTime) {
+		this.messageExpirationTime = messageExpirationTime;
+	}
 }

--- a/src/main/java/de/thoffbauer/signal4j/store/User.java
+++ b/src/main/java/de/thoffbauer/signal4j/store/User.java
@@ -9,6 +9,7 @@ public class User {
 	private String avatarId;
 	private String color;
 	private boolean blocked = false;
+	private int messageExpirationTime;
 	
 	public User() {
 		
@@ -64,4 +65,11 @@ public class User {
 		this.avatarId = avatarId;
 	}
 
+	public int getMessageExpirationTime() {
+		return messageExpirationTime;
+	}
+
+	public void setMessageExpirationTime(int messageExpirationTime) {
+		this.messageExpirationTime = messageExpirationTime;
+	}
 }


### PR DESCRIPTION
Storing the timer is necessary if one wants to interact with groups or users that make use of that feature [0]. Otherwise the library will always misbehave by resetting the timer. 


Shout-out to @Trolldemorted for debugging and fixing this issue with me.

[0] https://signal.org/blog/disappearing-messages/